### PR TITLE
update units.tsv

### DIFF
--- a/.tests/integration/units.tsv
+++ b/.tests/integration/units.tsv
@@ -1,2 +1,2 @@
-sample	unit	run	lane	fastq1	fastq2	adapter
+sample	type	run	lane	fastq1	fastq2	adapter
 NA12878	N	1	1	input/R1.fq.gz	input/R2.fq.gz	ACGT

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -28,9 +28,7 @@ validate(samples, schema="../schemas/samples.schema.yaml")
 
 ### Read and validate units file
 
-units = pd.read_table(config["units"], dtype=str).set_index(
-    ["sample", "unit", "run", "lane"], drop=False
-)
+units = pd.read_table(config["units"], dtype=str).set_index(["sample", "type", "run", "lane"], drop=False)
 validate(units, schema="../schemas/units.schema.yaml")
 
 ### Set wildcard constraints
@@ -39,16 +37,16 @@ validate(units, schema="../schemas/units.schema.yaml")
 wildcard_constraints:
     sample="|".join(samples.index),
 
+
 def get_fastq(wildcards):
-    fastqs = units.loc[
-        (wildcards.sample, wildcards.unit, wildcards.run, wildcards.lane), ["fastq1", "fastq2"]
-    ].dropna()
+    fastqs = units.loc[(wildcards.sample, wildcards.type, wildcards.run, wildcards.lane), ["fastq1", "fastq2"]].dropna()
     return {"fwd": fastqs.fastq1, "rev": fastqs.fastq2}
 
 
 def get_sample_fastq(wildcards):
-    fastqs = units.loc[(wildcards.sample, wildcards.unit), ["fastq1", "fastq2"]].dropna()
+    fastqs = units.loc[(wildcards.sample, wildcards.type), ["fastq1", "fastq2"]].dropna()
     return {"fwd": fastqs["fastq1"].tolist(), "rev": fastqs["fastq2"].tolist()}
+
 
 def compile_output_list(wildcards):
     return ["dummy.txt"]

--- a/workflow/schemas/units.schema.yaml
+++ b/workflow/schemas/units.schema.yaml
@@ -4,9 +4,9 @@ properties:
   sample:
     type: string
     description: sample id
-  unit:
+  type:
     type: string
-    description: type of sample
+    description: type of sample data Tumor, Normal, RNA (N|T|R)
   run:
     type: string
     description: sequencing run id
@@ -24,7 +24,7 @@ properties:
     description: one or more sequence, separated by ","
 required:
   - sample
-  - unit
+  - type
   - run
   - lane
   - fastq1


### PR DESCRIPTION
Refactor: change column unit to type in units.tsv file

Currently there is a column in units.tsv named "unit" which describe data type, e.g Normal (N) or Tumor (T) or RNA (R) sample data. Having a file named units.tsv with a column named unit is a bit confusing.

### Review and tests: 
- [x] Tests pass
- [x] Code review
